### PR TITLE
Remove `UnsafeUserParameters`

### DIFF
--- a/userparameter_cputemp.conf
+++ b/userparameter_cputemp.conf
@@ -1,5 +1,3 @@
-UnsafeUserParameters=1
-
 UserParameter=basicCPUTemp.min,sensors | grep Core | awk -F'[:+°]' '{if(min==""){min=$3}; if($3<min) {min=$3};} END {print min}'
 UserParameter=basicCPUTemp.max,sensors | grep Core | awk -F'[:+°]' '{if(max==""){max=$3}; if(max<$3) {max=$3};} END {print max}'
 UserParameter=basicCPUTemp.avg,sensors | grep Core | awk -F'[:+°]' '{avg+=$3}END{print avg/NR}'


### PR DESCRIPTION
This parameter is a little confusing, after some no luck google attempts,  I found this: https://bugzilla.redhat.com/show_bug.cgi?id=1037941
Zabbix documents are all there, but seems a little disconnected from each other.

`UnsafeUserParameters` is meant for limiting "Flexible user parameters",
we are using "Simple user parameters" only in this config file. Default
value is safer, and by not setting this at all, it will be easier to
manage when we need to set this in another config file in the future.
