### PR TITLE
Dropped dependency with lm-sensors

### DIFF
--- a/userparameter_cputemp.conf
+++ b/userparameter_cputemp.conf
@@ -1,3 +1,1 @@
-UserParameter=basicCPUTemp.min,sensors | grep Core | awk -F'[:+°]' '{if(min==""){min=$3}; if($3<min) {min=$3};} END {print min}'
-UserParameter=basicCPUTemp.max,sensors | grep Core | awk -F'[:+°]' '{if(max==""){max=$3}; if(max<$3) {max=$3};} END {print max}'
-UserParameter=basicCPUTemp.avg,sensors | grep Core | awk -F'[:+°]' '{avg+=$3}END{print avg/NR}'
+UserParameter=system.cpu.temp,echo $(cat /sys/class/thermal/thermal_zone0/temp) 1000 | awk '{print $1/$2}'


### PR DESCRIPTION
lm-sensors is an old package and doesn't work anymore on my side. Replaced by the native way to get the CPU temperature on Linux.